### PR TITLE
Allow `path` in `load_player_config` to be `None`

### DIFF
--- a/rlbot/config.py
+++ b/rlbot/config.py
@@ -217,7 +217,7 @@ def load_player_loadout(path: Path | str, team: int) -> flat.PlayerLoadout:
 
 
 def load_player_config(
-    path: Path | str,
+    path: Path | str | None,
     type: flat.CustomBot | flat.Psyonix,
     team: int,
     name_override: str | None = None,
@@ -227,6 +227,20 @@ def load_player_config(
     Reads the bot toml file at the provided path and
     creates a `PlayerConfiguration` of the given type for the given team.
     """
+    if path is None:
+        loadout = (
+            load_player_loadout(loadout_override, team)
+            if loadout_override is not None
+            else None
+        )
+
+        return flat.PlayerConfiguration(
+            type,
+            name_override or "",
+            team,
+            loadout=loadout,
+        )
+
     path = Path(path)
     with open(path, "rb") as f:
         config = tomllib.load(f)

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.41"
+__version__ = "2.0.0-beta.42"

--- a/tests/nexto/toxic.bot.toml
+++ b/tests/nexto/toxic.bot.toml
@@ -1,3 +1,4 @@
+#:schema https://rlbot.org/schemas/agent.json
 [settings]
 name = "Nexto (Toxic!)"
 loadout_file = "loadout.toml"

--- a/tests/psy.toml
+++ b/tests/psy.toml
@@ -9,7 +9,6 @@ game_map_upk = "Stadium_P"
 
 [[cars]]
 team = 0
-config_file = "psy/bot.toml"
 type = "Psyonix"
 skill = "Beginner"
 


### PR DESCRIPTION
Reduces confusion when trying to include a Psyonix bot in a match. This PR allows `load_player_config(None, flat.Psyonix(flat.PsyonixSkill.AllStar), 0)` to work, which will result in `PlayerConfiguration(variety=Psyonix(bot_skill=PsyonixSkill.AllStar), name="", team=0, root_dir="", run_command="", loadout=None, spawn_id=0, agent_id="", hivemind=False)`