### PR TITLE
fix: allow non-default ports to be sent to the server binary on Linux

### DIFF
--- a/rlbot/utils/gateway.py
+++ b/rlbot/utils/gateway.py
@@ -77,7 +77,7 @@ def launch(
     if CURRENT_OS == "Windows":
         args = [str(path), str(port)]
     else:
-        args = f"{path} {port}" # on Unix, when shell=True, args must be a string for flags to reach the executable
+        args = f"{path} {port}"  # on Unix, when shell=True, args must be a string for flags to reach the executable
     DEFAULT_LOGGER.info("Launching RLBotServer with via %s", args)
 
     return subprocess.Popen(args, shell=True, cwd=directory), port

--- a/rlbot/utils/gateway.py
+++ b/rlbot/utils/gateway.py
@@ -9,6 +9,7 @@ import psutil
 
 from rlbot.interface import RLBOT_SERVER_PORT
 from rlbot.utils.logging import DEFAULT_LOGGER
+from rlbot.utils.os_detector import CURRENT_OS
 
 
 def find_main_executable_path(
@@ -72,7 +73,11 @@ def launch(
         )
 
     port = find_open_server_port()
-    args = [str(path), str(port)]
+
+    if CURRENT_OS == "Windows":
+        args = [str(path), str(port)]
+    else:
+        args = f"{path} {port}" # on Unix, when shell=True, args must be a string for flags to reach the executable
     DEFAULT_LOGGER.info("Launching RLBotServer with via %s", args)
 
     return subprocess.Popen(args, shell=True, cwd=directory), port

--- a/rlbot/utils/gateway.py
+++ b/rlbot/utils/gateway.py
@@ -11,6 +11,8 @@ from rlbot.interface import RLBOT_SERVER_PORT
 from rlbot.utils.logging import DEFAULT_LOGGER
 from rlbot.utils.os_detector import CURRENT_OS
 
+if CURRENT_OS != "Windows":
+    import shlex
 
 def find_main_executable_path(
     main_executable_path: Path, main_executable_name: str
@@ -77,7 +79,7 @@ def launch(
     if CURRENT_OS == "Windows":
         args = [str(path), str(port)]
     else:
-        args = f"{path} {port}"  # on Unix, when shell=True, args must be a string for flags to reach the executable
+        args = f"{shlex.quote(path.as_posix())} {port}"  # on Unix, when shell=True, args must be a string for flags to reach the executable
     DEFAULT_LOGGER.info("Launching RLBotServer with via %s", args)
 
     return subprocess.Popen(args, shell=True, cwd=directory), port


### PR DESCRIPTION
This PR fixes a minor bug that occurs on Linux when the gateway tries to ask the server to communicate on a non-default port if the default port (23234) is taken. 

The underlying issue is a quirk of `subprocess.Popen`. From [its docs](https://docs.python.org/3.12/library/subprocess.html#popen-constructor): 

> On POSIX with `shell=True`...if args is a sequence, the first item specifies the command string, and any additional items will be treated as additional arguments to the shell itself.

This means that when the gateway tries to pass a non-default port to the RLBotServer binary via `args = [str(path), str(port)]`, the `port` argument ends up getting sent to the shell and the server never sees it, which results in the gateway trying to talk on, say, 23235, while the server listens on 23234.

This PR fixes the problem by passing both the executable path and the port in a single string to Popen.