### PR TITLE
Add ContextManager pattern to MatchManager and RenderingManager plus default color

### DIFF
--- a/rlbot/managers/match.py
+++ b/rlbot/managers/match.py
@@ -34,7 +34,6 @@ class MatchManager:
         self.rlbot_interface.packet_handlers.append(self._packet_reporter)
 
     def __enter__(self) -> 'MatchManager':
-        self.ensure_server_started()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/rlbot/managers/match.py
+++ b/rlbot/managers/match.py
@@ -33,6 +33,13 @@ class MatchManager:
         self.rlbot_interface: SocketRelay = SocketRelay("")
         self.rlbot_interface.packet_handlers.append(self._packet_reporter)
 
+    def __enter__(self) -> 'MatchManager':
+        self.ensure_server_started()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.disconnect()
+
     def ensure_server_started(self):
         """
         Ensures that RLBotServer is running, starting it if it is not.

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.43"
+__version__ = "2.0.0-beta.44"

--- a/tests/render_test/render.py
+++ b/tests/render_test/render.py
@@ -1,3 +1,5 @@
+from email.policy import default
+
 from rlbot import flat
 from rlbot.flat import BallAnchor, CarAnchor, Color, RenderAnchor, Vector3
 from rlbot.managers import Script
@@ -30,12 +32,12 @@ class RenderFun(Script):
 
             self.do_render(radius)
 
-        self.renderer.begin_rendering('tick')
-        hsv = self.renderer.create_color_hsv(packet.match_info.seconds_elapsed * 0.1, 1.0, 1.0)
-        self.renderer.set_resolution(1920, 1080)
-        self.renderer.draw_string_2d('HSV 300px 50px', 300, 50, 1.0, hsv)
-        self.renderer.set_resolution(1, 1)
-        self.renderer.end_rendering()
+        with self.renderer.context('tick', self.renderer.red):
+            self.renderer.set_resolution(1920, 1080)
+            hsv = self.renderer.create_color_hsv(packet.match_info.seconds_elapsed * 0.1, 1.0, 1.0)
+            self.renderer.draw_string_2d('HSV 300px 50px', 300, 50, 1.0, hsv)
+            self.renderer.draw_string_2d('Red 330px 70px', 330, 70, 1.0)  # Use default color
+            self.renderer.set_resolution(1, 1)
 
     def do_render(self, radius: float):
         self.renderer.begin_rendering()
@@ -75,7 +77,7 @@ class RenderFun(Script):
         )
 
         self.renderer.draw_rect_2d(
-            0.75, 0.75, 0.1, 0.1, Color(150, 30, 100), centered=False
+            0.75, 0.75, 0.1, 0.1, Color(150, 30, 100)
         )
         self.renderer.draw_rect_2d(0.75, 0.75, 0.1, 0.1, self.renderer.black)
         for hkey, h in {

--- a/tests/run_match.py
+++ b/tests/run_match.py
@@ -10,14 +10,10 @@ MATCH_CONFIG_PATH = DIR / "human_vs_atba.toml"
 RLBOT_SERVER_FOLDER = DIR / "../../core/RLBotCS/bin/Release/"
 
 if __name__ == "__main__":
-    match_manager = MatchManager(RLBOT_SERVER_FOLDER)
+    with MatchManager(RLBOT_SERVER_FOLDER) as man:
+        man.start_match(MATCH_CONFIG_PATH)
+        assert man.packet is not None
 
-    match_manager.start_match(MATCH_CONFIG_PATH)
-    assert match_manager.packet is not None
-
-    try:
         # wait for the match to end
-        while match_manager.packet.match_info.match_phase != flat.MatchPhase.Ended:
+        while man.packet.match_info.match_phase != flat.MatchPhase.Ended:
             sleep(1.0)
-    finally:
-        match_manager.shut_down()

--- a/tests/run_only.py
+++ b/tests/run_only.py
@@ -14,13 +14,11 @@ if __name__ == "__main__":
         match_config_path = Path(sys.argv[1])
     assert match_config_path.exists(), f"Match config not found: {match_config_path}"
 
-    # start the match
-    match_manager = MatchManager(RLBOT_SERVER_FOLDER)
-    match_manager.start_match(match_config_path, False)
+    with MatchManager(RLBOT_SERVER_FOLDER) as man:
+        man.start_match(match_config_path, False)
 
-    # wait
-    input("\nPress enter to end the match: ")
+        # Wait for input
+        input("\nPress enter to end the match: ")
 
-    # end the match and disconnect
-    match_manager.stop_match()
-    match_manager.disconnect()
+        # End the match
+        man.stop_match()


### PR DESCRIPTION
It is now possible to do
```python
# Automatically call ensure_started and disconnect
with MatchManager(RLBOT_SERVER_FOLDER) as man:
    man.start_match(MATCH_CONFIG_PATH)
```
and
```python
# Automatically call begin_rendering, set_default_color, and end_rendering
with renderer.context(group_id='shot', default_color=renderer.red):
    renderer.draw_line_3d(car.pos, ball.pos)
    renderer.draw_line_3d(car.pos, goal.pos)
    renderer.draw_line_3d(ball.pos, goal.pos)
```
The addition of default color is also new.