### PR TITLE
End rendering on exception raise

### DIFF
--- a/rlbot/managers/bot.py
+++ b/rlbot/managers/bot.py
@@ -151,6 +151,8 @@ class Bot:
                 e,
             )
             print_exc()
+            if self.renderer.is_rendering():
+                self.renderer.end_rendering()
             return
 
         player_input = flat.PlayerInput(self.index, controller)

--- a/rlbot/managers/rendering.py
+++ b/rlbot/managers/rendering.py
@@ -154,6 +154,7 @@ class Renderer:
             )
             return
 
+        self._current_renders.clear()
         self._group_id = Renderer._get_group_id(group_id)
         self._used_group_ids.add(self._group_id)
 

--- a/rlbot/managers/script.py
+++ b/rlbot/managers/script.py
@@ -123,6 +123,8 @@ class Script:
             self.logger.error(
                 "Script %s encountered an error to RLBot: %s", self.name, e
             )
+            if self.renderer.is_rendering():
+                self.renderer.end_rendering()
             print_exc()
 
     def _run(self):

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.44"
+__version__ = "2.0.0-beta.45"


### PR DESCRIPTION
Fixes a bug where rendering would accumulate when exceptions were raised during packet handling.

Ala this
![billede](https://github.com/user-attachments/assets/deb58df3-ff2c-4565-80f7-6c5e6ae0209d)
