### PR TITLE
Beta 48

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 
+uv.lock
 .vscode/
 *.obj
 RLBotServer*

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ The following is how to setup a development environment for this project, NOT ho
   - `pip uninstall rlbot_flatbuffers`
   - `pip install --editable <path/to/rlbot_flatbuffers>`
 
-This project is formatted using [Black](https://github.com/psf/black).
+This project is formatted using [Ruff](https://docs.astral.sh/ruff/formatter/).
 
-- Install: `pip install black`.
-- Use: `black .`
+- Install: `pip install ruff`.
+- Sort imports: `ruff check --select I --fix`
+- Format code: `ruff format`
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,12 @@ Repository = "https://github.com/RLBot/python-interface"
 
 [tool.setuptools.dynamic]
 version = {attr = "rlbot.version.__version__"}
+
+[dependency-groups]
+dev = [
+    "ruff>=0.12.5",
+    "toml>=0.10.2",
+]
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/rlbot/__init__.py
+++ b/rlbot/__init__.py
@@ -1,1 +1,1 @@
-from .version import __version__
+from .version import __version__ as __version__

--- a/rlbot/config.py
+++ b/rlbot/config.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Literal
 
 import rlbot.flat as flat
-from rlbot.utils.logging import DEFAULT_LOGGER as logger
 from rlbot.utils.os_detector import CURRENT_OS, OS
 
 
@@ -112,7 +111,7 @@ def load_match_config(config_path: Path | str) -> flat.MatchConfiguration:
                     )
                 )
             case "human":
-                players.append(flat.PlayerConfiguration(flat.Human(), team, 0))
+                players.append(get_human(team))
             case t:
                 raise ConfigParsingException(
                     f"Invalid player type {repr(t)} for player {len(players)}."
@@ -321,6 +320,13 @@ def load_psyonix_config(
         team,
         0,
     )
+
+
+def get_human(team: int) -> flat.PlayerConfiguration:
+    """
+    Creates a `PlayerConfiguration` for a human player on the given team.
+    """
+    return flat.PlayerConfiguration(flat.Human(), team)
 
 
 def load_script_config(path: Path | str) -> flat.ScriptConfiguration:

--- a/rlbot/interface.py
+++ b/rlbot/interface.py
@@ -323,7 +323,7 @@ class SocketRelay:
             self.logger.critical("RLBot is not responding to our disconnect request!?")
             self._running = False
 
-        assert (
-            not self._running
-        ), "Disconnect request or timeout should have set self._running to False"
+        assert not self._running, (
+            "Disconnect request or timeout should have set self._running to False"
+        )
         self.is_connected = False

--- a/rlbot/managers/match.py
+++ b/rlbot/managers/match.py
@@ -93,6 +93,7 @@ class MatchManager:
             rlbot_server_ip=rlbot_server_ip,
             rlbot_server_port=rlbot_server_port or self.rlbot_server_port,
         )
+        self.rlbot_interface.run(background_thread=True)
 
     def wait_for_first_packet(self):
         while self.packet is None or self.packet.match_info.match_phase in {
@@ -122,7 +123,6 @@ class MatchManager:
                 wants_ball_predictions=False,
                 close_between_matches=False,
             )
-            self.rlbot_interface.run(background_thread=True)
 
         self.rlbot_interface.start_match(config)
 
@@ -136,7 +136,7 @@ class MatchManager:
 
     def disconnect(self):
         """
-        Disconnect from the RLBotServer.
+        Disconnect from RLBotServer.
         Note that the server will continue running as long as Rocket League does.
         """
         self.rlbot_interface.disconnect()
@@ -167,8 +167,8 @@ class MatchManager:
 
         self.logger.info("Shutting down RLBot...")
 
-        # In theory this is all we need for the server to cleanly shut itself down
         try:
+            # In theory this is all we need for the server to cleanly shut itself down
             self.rlbot_interface.stop_match(shutdown_server=True)
         except BrokenPipeError:
             match gateway.find_server_process(self.main_executable_name)[0]:

--- a/rlbot/utils/maps.py
+++ b/rlbot/utils/maps.py
@@ -60,7 +60,6 @@ GAME_MAP_TO_UPK = {
     "Barricade": "Labs_PillarHeat_P",
     "Colossus": "Labs_PillarWings_P",
     "BeckwithPark_Snowy": "Park_Snowy_P",
-    "NeoTokyo_Comic": "NeoTokyo_Toon_P",
     "UtopiaColiseum_Gilded": "UtopiaStadium_Lux_P",
     "SovereignHeights": "Street_P",
     "Hoops_TheBlock": "HoopsStreet_P",
@@ -139,4 +138,5 @@ STANDARD_MAPS = [
     "FuturaGarden",
     "DFHStadium_Anniversary",
     "DriftWoods_Night",
+    "NeoTokyo_Comic",
 ]

--- a/rlbot/utils/maps.py
+++ b/rlbot/utils/maps.py
@@ -60,6 +60,7 @@ GAME_MAP_TO_UPK = {
     "Barricade": "Labs_PillarHeat_P",
     "Colossus": "Labs_PillarWings_P",
     "BeckwithPark_Snowy": "Park_Snowy_P",
+    "NeoTokyo_Comic": "NeoTokyo_Toon_P",
     "UtopiaColiseum_Gilded": "UtopiaStadium_Lux_P",
     "SovereignHeights": "Street_P",
     "Hoops_TheBlock": "HoopsStreet_P",

--- a/rlbot/utils/maps.py
+++ b/rlbot/utils/maps.py
@@ -83,7 +83,7 @@ GAME_MAP_TO_UPK = {
     "FuturaGarden": "UF_Day_P",
     "DFHStadium_Anniversary": "stadium_10a_p",
     "Holyfield": "Labs_Holyfield_Space_P",
-    "DriftWoods_Night": "woods_night_p"
+    "DriftWoods_Night": "woods_night_p",
 }
 
 STANDARD_MAPS = [
@@ -138,5 +138,5 @@ STANDARD_MAPS = [
     "Neotokyo_Arcade",
     "FuturaGarden",
     "DFHStadium_Anniversary",
-    "DriftWoods_Night"
+    "DriftWoods_Night",
 ]

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.47"
+__version__ = "2.0.0-beta.48"

--- a/tests/atba/atba.bot.toml
+++ b/tests/atba/atba.bot.toml
@@ -14,7 +14,7 @@ root_dir = ""
 run_command = "..\\..\\venv\\Scripts\\python atba.py"
 # The command RLBot will call to start your bot on linux
 # If this isn't set, RLBot may attempt to run the Windows command under Wine
-run_command_linux = "../../venv/bin/python atba.py"
+run_command_linux = "../../.venv/bin/python atba.py"
 
 [details]
 description = "Made possible by RLBot"

--- a/tests/cfg_to_toml.py
+++ b/tests/cfg_to_toml.py
@@ -113,9 +113,9 @@ class Bot:
 
         toml_dict["settings"] = self._convert_settings()
         toml_dict["details"] = self._convert_details()
-        toml_dict["settings"][
-            "agent_id"
-        ] = f"{toml_dict["details"]["developer"]}/{toml_dict["settings"]["name"]}"
+        toml_dict["settings"]["agent_id"] = (
+            f"{toml_dict['details']['developer']}/{toml_dict['settings']['name']}"
+        )
 
         return toml_dict
 

--- a/tests/fashion/bot.py
+++ b/tests/fashion/bot.py
@@ -50,7 +50,7 @@ class Fashion(Bot):
                 ),
             )
 
-            self.logger.info(f"State setting new loadout")
+            self.logger.info("State setting new loadout")
             self.set_loadout(loadout)
             self.last_tick = packet.match_info.frame_num
 

--- a/tests/many_match.py
+++ b/tests/many_match.py
@@ -23,10 +23,11 @@ if __name__ == "__main__":
     match_manager = MatchManager(RLBOT_SERVER_FOLDER)
     match_manager.rlbot_interface.match_comm_handlers.append(handle_match_comm)
     match_manager.ensure_server_started()
-    match_manager.connect(
+    match_manager.connect_and_run(
         wants_match_communications=True,
         wants_ball_predictions=False,
         close_between_matches=False,
+        background_thread=False,
     )
 
     current_map = -1

--- a/tests/many_match.py
+++ b/tests/many_match.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from time import sleep
+
+from rlbot import flat
+from rlbot.config import load_player_config
+from rlbot.managers import MatchManager
+
+DIR = Path(__file__).parent
+
+BOT_PATH = DIR / "atba/atba.bot.toml"
+RLBOT_SERVER_FOLDER = DIR / "../../core/RLBotCS/bin/Release/"
+
+num_comms = set()
+
+
+def handle_match_comm(comm: flat.MatchComm):
+    global num_comms
+    if comm.team < 2:
+        num_comms.add(comm.index)
+
+
+if __name__ == "__main__":
+    match_manager = MatchManager(RLBOT_SERVER_FOLDER)
+    match_manager.rlbot_interface.match_comm_handlers.append(handle_match_comm)
+    match_manager.ensure_server_started()
+    match_manager.connect(
+        wants_match_communications=True,
+        wants_ball_predictions=False,
+        close_between_matches=False,
+    )
+
+    current_map = -1
+
+    blue_bot = load_player_config(BOT_PATH, 0)
+    orange_bot = load_player_config(BOT_PATH, 1)
+
+    match_settings = flat.MatchConfiguration(
+        launcher=flat.Launcher.Steam,
+        auto_start_agents=True,
+        wait_for_agents=True,
+        existing_match_behavior=flat.ExistingMatchBehavior.Restart,
+        game_map_upk="Stadium_P",
+        instant_start=True,
+        enable_state_setting=True,
+        player_configurations=[
+            blue_bot,
+            blue_bot,
+            blue_bot,
+            blue_bot,
+            blue_bot,
+            orange_bot,
+            orange_bot,
+            orange_bot,
+            orange_bot,
+            orange_bot,
+        ],
+    )
+
+    num_games = 0
+    paused = False
+
+    while not paused:
+        num_games += 1
+        print(f"Starting match # {num_games}")
+
+        match_manager.start_match(match_settings, ensure_server_started=False)
+        # when calling start_match, by default it will wait for the first packet
+        assert match_manager.packet is not None
+
+        sleep(2)
+        num_comms.clear()
+        while len(num_comms) < 10:
+            # give an extra 5 seconds for the match to start before calling it a failure
+            if (
+                match_manager.packet.match_info.match_phase == flat.MatchPhase.Active
+                and match_manager.packet.match_info.game_time_remaining < 60 * 4 + 55
+            ):
+                match_manager.set_game_state(commands=["Pause"])
+                paused = True
+                break
+            sleep(1)
+
+    print("Failed to start match. Paused and exiting.")
+    match_manager.disconnect()

--- a/tests/nexto/bot.py
+++ b/tests/nexto/bot.py
@@ -369,7 +369,6 @@ class Nexto(Bot):
                 return
 
             for p in human_opps:
-
                 d = math.sqrt(
                     (p.physics.location.x - bad_goal[0]) ** 2
                     + (p.physics.location.y - bad_goal[1]) ** 2

--- a/tests/nexto/nexto_obs.py
+++ b/tests/nexto/nexto_obs.py
@@ -286,8 +286,7 @@ class NextoObsBuilder(BatchedObsBuilder):
         for i in range(n_players):
             encoded_player = encoded_states[
                 :,
-                players_start_index
-                + i * player_length : players_start_index
+                players_start_index + i * player_length : players_start_index
                 + (i + 1) * player_length,
             ]
 

--- a/tests/run_forever.py
+++ b/tests/run_forever.py
@@ -13,7 +13,6 @@ RLBOT_SERVER_FOLDER = DIR / "../../core/RLBotCS/bin/Release/"
 
 if __name__ == "__main__":
     match_manager = MatchManager(RLBOT_SERVER_FOLDER)
-    match_manager.ensure_server_started()
 
     current_map = -1
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -16,7 +16,6 @@ if __name__ == "__main__":
     match_manager = MatchManager(RLBOT_SERVER_FOLDER)
 
     try:
-        match_manager.ensure_server_started()
         match_manager.start_match(MATCH_CONFIG_PATH)
 
         logger.info("Waiting before shutdown...")
@@ -25,7 +24,7 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         logger.warning("Shutting down early due to interrupt")
     except Exception:
-        logger.critical(f"Shutting down early due to the following error:")
+        logger.critical("Shutting down early due to the following error:")
         print_exc()
 
     match_manager.shut_down()


### PR DESCRIPTION
Beta 48 changes:

- Add `get_human` to reduce confusion as `load_player_config` and `load_psyonix_config` both exist
- Migrate from formatting the project with isort & black to ruff
- Add `MatchManager.run(...)` and `MatchManager.connect_and_run(...)`
- Add `NeoTokyo_Comic` to `STANDARD_MAPS`

Changes within `tests/`

- Fix `cfg_to_toml.py` not working in Python 3.11
- `many_match` test + changes to example atba to make it work